### PR TITLE
feature: allow negative line number

### DIFF
--- a/errorformat.go
+++ b/errorformat.go
@@ -409,7 +409,8 @@ type Efm struct {
 var fmtpattern = map[byte]string{
 	'f': `(?P<f>(?:[[:alpha:]]:)?(?:\\ |[^ ])+?)`,
 	'n': `(?P<n>\d+)`,
-	'l': `(?P<l>\d+)`,
+	// Negative line number is supported as special markers.
+	'l': `(?P<l>-?\d+)`,
 	'c': `(?P<c>\d+)`,
 	't': `(?P<t>.)`,
 	'm': `(?P<m>.+)`,


### PR DESCRIPTION
This will allow using line number zero or negative in Reviewdog. See [1]
for a use case.

[1] https://github.com/haya14busa/reviewdog/issues/92#issuecomment-299137785