### PR TITLE
fix phpstan doc

### DIFF
--- a/fmts/doc.go
+++ b/fmts/doc.go
@@ -16,7 +16,7 @@
 // 		eslint	(eslint [-f stylish]) A fully pluggable tool for identifying and reporting on patterns in JavaScript - https://github.com/eslint/eslint
 // 		eslint-compact	(eslint -f compact) A fully pluggable tool for identifying and reporting on patterns in JavaScript - https://github.com/eslint/eslint
 // 	php
-// 		phpstan	(phpstan --errorFormat=raw) PHP Static Analysis Tool - discover bugs in your code without running it! - https://github.com/phpstan/phpstan
+// 		phpstan	(phpstan --error-format=raw) PHP Static Analysis Tool - discover bugs in your code without running it! - https://github.com/phpstan/phpstan
 // 	python
 // 		pep8	Python style guide checker - https://pypi.python.org/pypi/pep8
 // 	ruby

--- a/fmts/php.go
+++ b/fmts/php.go
@@ -8,7 +8,7 @@ func init() {
 		Errorformat: []string{
 			`%f:%l:%m`,
 		},
-		Description: "(phpstan --errorFormat=raw) PHP Static Analysis Tool - discover bugs in your code without running it!",
+		Description: "(phpstan --error-format=raw) PHP Static Analysis Tool - discover bugs in your code without running it!",
 		URL:         "https://github.com/phpstan/phpstan",
 		Language:    lang,
 	})


### PR DESCRIPTION
Fix `phpstan` docs.
Usage of `--errorFormat` is deprecated.
Use `--error-format` instead.